### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/versatiles-org/versatiles-choro/security/code-scanning/7](https://github.com/versatiles-org/versatiles-choro/security/code-scanning/7)

To fix this issue, the workflow should explicitly declare a `permissions` block, either at the root (affecting all jobs) or at the job level (recommended for granularity). The minimal permission required for most Docker CI/CD workflows is `contents: read` (for actions/checkout), and since this workflow pushes to GitHub Container Registry (GHCR), it also requires `packages: write`. Add this block at the job level for the `build` job in `.github/workflows/docker.yml` directly under `runs-on: ubuntu-latest`. No additional imports or external configuration is needed, just direct edit to the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
